### PR TITLE
Add docker container steps to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,24 @@ To submit a pull request to the documentation, follow this process:
   </pre>
 
 1. Make your changes. 
- 
+
+1. Get a ruby environment. 
+   If you don't have a ruby environment on your local machine, we suggest using a docker container. The following command assumes you have the docs repos cloned at `~/workspace/DOCS_REPO` on your local machine.
+   <pre>
+   $ docker run -it --mount type=bind,source="$HOME/workspace",target=/workspace -p 4567:4567 ruby:2.3 /bin/bash
+   </pre>
+   
+1. Go to the docs-book-cloudfoundry repo
+   <pre>
+   # if you are executing bookbinder from your local ruby environment
+   $ cd docs-book-cloudfoundry
+   
+   # if you are executing bookbinder from the docker container from the command above
+   $ cf /workspace/docs-book-cloudfoundry
+   </pre>
 1. Run bookbinder on your local changes:
 
   <pre>
-    $ cd docs-book-cloudfoundry
     $ bundle install
     $ bundle exec bookbinder watch
   </pre>


### PR DESCRIPTION
We don't work with ruby on our machines so it's easier to spin up a docker container with some mounting and port forwarding. 

This work was done by @jrussett. Thanks Josh :D